### PR TITLE
Hack vllm to support JAX model runner.

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -115,6 +115,7 @@ if TYPE_CHECKING:
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
+    VLLM_USE_JAX: bool = False
 
 
 def get_default_cache_root():
@@ -764,6 +765,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Port used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_PORT":
     lambda: int(os.getenv("VLLM_NIXL_SIDE_CHANNEL_PORT", "5557")),
+
+    "VLLM_USE_JAX":
+    lambda: bool(int(os.getenv("VLLM_USE_JAX", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, Optional, TypeVar
 import torch
 import torch.nn as nn
 
+import vllm.envs as envs
+
 from .interfaces_base import VllmModelForPooling, is_pooling_model
 
 if TYPE_CHECKING:
@@ -125,6 +127,10 @@ def as_embedding_model(cls: _T) -> _T:
         We assume that no extra layers are added to the original model;
         please implement your own model if this is not the case.
     """
+    if envs.VLLM_USE_JAX:
+        # hack
+        return cls  # Returning jax model as is
+
     # Avoid modifying existing embedding models
     if is_pooling_model(cls):
         return cls

--- a/vllm/model_executor/models/llama_jax.py
+++ b/vllm/model_executor/models/llama_jax.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Adapted from
+# https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/models/llama/modeling_llama.py
+# Copyright 2023 The vLLM team.
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference-only LLaMA model compatible with HuggingFace weights."""
+from typing import Optional, Union
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.model_executor.models import VllmModelForTextGeneration
+from vllm.sequence import IntermediateTensors
+
+
+class _FusionMeta(type(nnx.Module), type(VllmModelForTextGeneration)):
+    pass
+
+
+class SimpleLayer(nnx.Module):
+
+    def __init__(self, layer_id):
+        self.layer_id = id
+        compilation_config = get_current_vllm_config().compilation_config
+        compilation_config.static_forward_context[f'layers.{layer_id}'] = self
+
+    def __call__(self, x):
+        return x * 2
+
+
+class JAXLlamaForCausalLM(nnx.Module,
+                          VllmModelForTextGeneration,
+                          metaclass=_FusionMeta):
+
+    def __init__(self,
+                 *,
+                 vllm_config: VllmConfig,
+                 prefix: str = "",
+                 layer_type: str = ""):
+        parallel_config = vllm_config.parallel_config
+        self.layers = [
+            SimpleLayer(layer_id=i) for i in range(
+                vllm_config.model_config.get_num_layers(parallel_config))
+        ]
+
+    def named_parameters(self):
+        return set()
+
+    def load_weights(self, *args, **kwargs):
+        return set()
+
+    def named_modules(self, *args, **kwargs):
+        return set()
+
+    def __call__(
+        self,
+        input_ids: jax.Array,
+        positions: jax.Array,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[jax.Array] = None,
+    ) -> Union[jax.Array, IntermediateTensors]:
+        x = jnp.ones((2, 4))
+        for layer in self.layers:
+            x = layer(x)
+        return x

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -18,6 +18,7 @@ from typing import (AbstractSet, Callable, Dict, List, Optional, Tuple, Type,
 import cloudpickle
 import torch.nn as nn
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 
 from .interfaces import (has_inner_state, has_noops, is_attention_free,
@@ -118,6 +119,10 @@ _TEXT_GENERATION_MODELS = {
     "BartModel": ("bart", "BartForConditionalGeneration"),
     "BartForConditionalGeneration": ("bart", "BartForConditionalGeneration"),
 }
+
+# hack
+if envs.VLLM_USE_JAX:
+    _TEXT_GENERATION_MODELS['LlamaForCausalLM'] = ("llama_jax", "JAXLlamaForCausalLM")
 
 _EMBEDDING_MODELS = {
     # [Text-only]

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -134,22 +134,25 @@ class TpuPlatform(Platform):
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config
         if parallel_config.worker_cls == "auto":
-            if scheduler_config.is_multi_step:
-                if envs.VLLM_USE_V1:
-                    raise NotImplementedError(
-                        "Multi-step scheduling is not supported (and not "
-                        "needed) on vLLM V1. Please launch without "
-                        "--num-scheduler-steps.")
-                else:
-                    parallel_config.worker_cls = \
-                        "vllm.worker.multi_step_tpu_worker.MultiStepTPUWorker"
+            if envs.VLLM_USE_JAX:
+                parallel_config.worker_cls = "vllm.v1.worker.tpu_worker_jax.JAXTPUWorker"
             else:
-                if envs.VLLM_USE_V1:
-                    parallel_config.worker_cls = \
-                        "vllm.v1.worker.tpu_worker.TPUWorker"
+                if scheduler_config.is_multi_step:
+                    if envs.VLLM_USE_V1:
+                        raise NotImplementedError(
+                            "Multi-step scheduling is not supported (and not "
+                            "needed) on vLLM V1. Please launch without "
+                            "--num-scheduler-steps.")
+                    else:
+                        parallel_config.worker_cls = \
+                            "vllm.worker.multi_step_tpu_worker.MultiStepTPUWorker"
                 else:
-                    parallel_config.worker_cls = \
-                        "vllm.worker.tpu_worker.TPUWorker"
+                    if envs.VLLM_USE_V1:
+                        parallel_config.worker_cls = \
+                            "vllm.v1.worker.tpu_worker.TPUWorker"
+                    else:
+                        parallel_config.worker_cls = \
+                            "vllm.worker.tpu_worker.TPUWorker"
 
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TPU backend")

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -50,6 +50,8 @@ from uuid import uuid4
 
 import cachetools
 import cloudpickle
+import jax
+import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
 import psutil
@@ -964,7 +966,12 @@ def async_tensor_h2d(
 
 def get_dtype_size(dtype: torch.dtype) -> int:
     """Get the size of the data type in bytes."""
-    return torch.tensor([], dtype=dtype).element_size()
+    if isinstance(dtype, torch.Tensor):
+        return torch.tensor([], dtype=dtype).element_size()
+    elif isinstance(dtype, jax._src.numpy.scalar_types._ScalarMeta):
+        return jnp.array([], dtype=dtype).itemsize
+    else:
+        raise NotImplementedError()
 
 
 # `collections` helpers

--- a/vllm/v1/worker/input_batch_jax.py
+++ b/vllm/v1/worker/input_batch_jax.py
@@ -1,0 +1,678 @@
+# SPDX-License-Identifier: Apache-2.0
+# Datastructures defining an input batch
+
+from dataclasses import dataclass
+from typing import Any, Optional, cast
+
+import jax
+import jax.numpy as jnp
+
+from vllm.lora.request import LoRARequest
+from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
+from vllm.sampling_params import SamplingParams, SamplingType
+from vllm.utils import swap_dict_values
+from vllm.v1.outputs import LogprobsTensors
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.worker.block_table import BlockTable
+
+_SAMPLING_EPS = 1e-5
+
+
+@dataclass
+class CachedRequestState:
+
+    req_id: str
+    prompt_token_ids: list[int]
+    mm_inputs: list[MultiModalKwargs]
+    mm_positions: list[PlaceholderRange]
+    sampling_params: SamplingParams
+    generator: Any
+
+    block_ids: list[int]
+    num_computed_tokens: int
+    output_token_ids: list[int]
+
+    mrope_positions: Optional[jax.Array] = None
+    mrope_position_delta: Optional[int] = None
+
+    lora_request: Optional[LoRARequest] = None
+
+    def __post_init__(self):
+        self.num_prompt_tokens = len(self.prompt_token_ids)
+
+    @property
+    def num_tokens(self) -> int:
+        return self.num_prompt_tokens + len(self.output_token_ids)
+
+    def get_token_id(self, idx: int) -> int:
+        if idx < self.num_prompt_tokens:
+            return self.prompt_token_ids[idx]
+        else:
+            return self.output_token_ids[idx - self.num_prompt_tokens]
+
+
+class InputBatch:
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        max_model_len: int,
+        max_num_blocks_per_req: int,
+        max_num_batched_tokens: int,
+        device: jax.Device,
+        pin_memory: bool,
+        vocab_size: int,
+    ):
+        self.max_num_reqs = max_num_reqs
+        self.max_model_len = max_model_len
+        self.max_num_blocks_per_req = max_num_blocks_per_req
+        self.max_num_batched_tokens = max_num_batched_tokens
+        self.device = device
+        self.pin_memory = pin_memory
+        self.vocab_size = vocab_size
+
+        self._req_ids: list[Optional[str]] = []
+        self.req_id_to_index: dict[str, int] = {}
+
+        self.token_ids_cpu = jnp.zeros(
+            (max_num_reqs, max_model_len),
+            dtype=jnp.int32,
+        )
+        self.num_tokens = jnp.zeros(max_num_reqs, dtype=jnp.int32)
+        self.num_tokens_no_spec = jnp.zeros(max_num_reqs, dtype=jnp.int32)
+        self.num_prompt_tokens = jnp.zeros(max_num_reqs, dtype=jnp.int32)
+        self.num_computed_tokens_cpu = jnp.zeros(
+            (max_num_reqs, ),
+            dtype=jnp.int32,
+        )
+
+        self.block_table = BlockTable(
+            max_num_reqs=max_num_reqs,
+            max_num_blocks_per_req=max_num_blocks_per_req,
+            max_num_batched_tokens=max_num_batched_tokens,
+            pin_memory=pin_memory,
+            device=device,
+        )
+
+        self.temperature = jax.device_put(
+            jnp.empty((max_num_reqs, ), dtype=jnp.float32), self.device)
+        self.temperature_cpu = jnp.empty((max_num_reqs, ), dtype=jnp.float32)
+        self.greedy_reqs: set[str] = set()
+        self.random_reqs: set[str] = set()
+
+        self.top_p = jax.device_put(
+            jnp.empty((max_num_reqs, ), dtype=jnp.float32), self.device)
+        self.top_p_cpu = jnp.empty((max_num_reqs, ), dtype=jnp.float32)
+        self.top_p_reqs: set[str] = set()
+
+        self.top_k = jax.device_put(
+            jnp.empty((max_num_reqs, ), dtype=jnp.int32), self.device)
+        self.top_k_cpu = jnp.empty((max_num_reqs, ), dtype=jnp.int32)
+        self.top_k_reqs: set[str] = set()
+
+        self.min_p = jax.device_put(
+            jnp.empty((max_num_reqs, ), dtype=jnp.float32), self.device)
+        self.min_p_cpu = jnp.empty((max_num_reqs, ), dtype=jnp.float32)
+        self.min_p_reqs: set[str] = set()
+
+        self.frequency_penalties = jax.device_put(
+            jnp.empty((max_num_reqs, ), dtype=jnp.float32), self.device)
+        self.frequency_penalties_cpu = jnp.empty((max_num_reqs, ),
+                                                 dtype=jnp.float32)
+        self.frequency_penalties_reqs: set[str] = set()
+
+        self.presence_penalties = jax.device_put(
+            jnp.empty((max_num_reqs, ), dtype=jnp.float32), self.device)
+        self.presence_penalties_cpu = jnp.empty((max_num_reqs, ),
+                                                dtype=jnp.float32)
+        self.presence_penalties_reqs: set[str] = set()
+
+        self.repetition_penalties = jax.device_put(
+            jnp.empty((max_num_reqs, ), dtype=jnp.float32), self.device)
+        self.repetition_penalties_cpu = jnp.empty((max_num_reqs, ),
+                                                  dtype=jnp.float32)
+        self.repetition_penalties_reqs: set[str] = set()
+
+        self.min_tokens: dict[int, tuple[int, set[int]]] = {}
+
+        self.request_lora_mapping = jnp.zeros((self.max_num_reqs, ),
+                                              dtype=jnp.int32)
+        self.lora_id_to_request_ids: dict[int, set[str]] = {}
+        self.lora_id_to_lora_request: dict[int, LoRARequest] = {}
+
+        self.generators: dict[int, jax.random.PRNGKeyArray] = {}
+
+        self.num_logprobs: dict[str, int] = {}
+        self.num_prompt_logprobs: dict[str, int] = {}
+
+        self.in_progress_prompt_logprobs_cpu: dict[str, LogprobsTensors] = {}
+
+        self.logit_bias: list[Optional[dict[int,
+                                            float]]] = [None] * max_num_reqs
+        self.has_allowed_token_ids: set[str] = set()
+        self.allowed_token_ids_mask: Optional[jax.Array] = None
+        self.allowed_token_ids_mask_cpu: Optional[jax.Array] = None
+
+        self.bad_words_token_ids: dict[int, list[list[int]]] = {}
+        self.req_output_token_ids: list[Optional[list[int]]] = []
+        self.sampling_metadata = self._make_sampling_metadata()
+
+    @property
+    def req_ids(self) -> list[str]:
+        return cast(list[str], self._req_ids)
+
+    def add_request(
+        self,
+        request: "CachedRequestState",
+        req_index: Optional[int] = None,
+    ) -> None:
+        if req_index is None:
+            req_index = self.num_reqs
+        assert req_index < self.max_num_reqs
+
+        req_id = request.req_id
+        if req_index == len(self._req_ids):
+            self._req_ids.append(req_id)
+            self.req_output_token_ids.append(request.output_token_ids)
+        else:
+            self._req_ids[req_index] = req_id
+            self.req_output_token_ids[req_index] = request.output_token_ids
+
+        self.req_id_to_index[req_id] = req_index
+
+        num_prompt_tokens = len(request.prompt_token_ids)
+        self.num_prompt_tokens = self.num_prompt_tokens.at[req_index].set(
+            num_prompt_tokens)
+        self.token_ids_cpu = self.token_ids_cpu.at[
+            req_index, :num_prompt_tokens].set(
+                jnp.array(request.prompt_token_ids, dtype=jnp.int32))
+        start_idx = num_prompt_tokens
+        end_idx = start_idx + len(request.output_token_ids)
+        if request.output_token_ids:
+            self.token_ids_cpu = self.token_ids_cpu.at[
+                req_index, start_idx:end_idx].set(
+                    jnp.array(request.output_token_ids, dtype=jnp.int32))
+
+        self.num_tokens = self.num_tokens.at[req_index].set(request.num_tokens)
+        self.num_tokens_no_spec = self.num_tokens_no_spec.at[req_index].set(
+            request.num_tokens)
+
+        self.num_computed_tokens_cpu = self.num_computed_tokens_cpu.at[
+            req_index].set(request.num_computed_tokens)
+        self.block_table.add_row(request.block_ids, req_index)
+
+        sampling_params = request.sampling_params
+        if sampling_params.sampling_type == SamplingType.GREEDY:
+            self.temperature_cpu = self.temperature_cpu.at[req_index].set(-1.0)
+            self.greedy_reqs.add(req_id)
+        else:
+            self.temperature_cpu = self.temperature_cpu.at[req_index].set(
+                sampling_params.temperature)
+            self.random_reqs.add(req_id)
+
+        self.top_p_cpu = self.top_p_cpu.at[req_index].set(
+            sampling_params.top_p)
+        if sampling_params.top_p < 1:
+            self.top_p_reqs.add(req_id)
+        top_k = sampling_params.top_k
+        if 0 < top_k < self.vocab_size:
+            self.top_k_reqs.add(req_id)
+        else:
+            top_k = self.vocab_size
+        self.top_k_cpu = self.top_k_cpu.at[req_index].set(top_k)
+        self.min_p_cpu = self.min_p_cpu.at[req_index].set(
+            sampling_params.min_p)
+        if sampling_params.min_p > _SAMPLING_EPS:
+            self.min_p_reqs.add(req_id)
+
+        self.frequency_penalties_cpu = self.frequency_penalties_cpu.at[
+            req_index].set(sampling_params.frequency_penalty)
+        if sampling_params.frequency_penalty != 0.0:
+            self.frequency_penalties_reqs.add(req_id)
+
+        self.presence_penalties_cpu = self.presence_penalties_cpu.at[
+            req_index].set(sampling_params.presence_penalty)
+        if sampling_params.presence_penalty != 0.0:
+            self.presence_penalties_reqs.add(req_id)
+
+        self.repetition_penalties_cpu = self.repetition_penalties_cpu.at[
+            req_index].set(sampling_params.repetition_penalty)
+        if sampling_params.repetition_penalty != 1.0:
+            self.repetition_penalties_reqs.add(req_id)
+
+        if sampling_params.min_tokens:
+            self.min_tokens[req_index] = (sampling_params.min_tokens,
+                                          sampling_params.all_stop_token_ids)
+
+        if request.generator is not None:
+            self.generators[req_index] = request.generator
+
+        if sampling_params.logprobs is not None:
+            self.num_logprobs[req_id] = sampling_params.logprobs
+        if sampling_params.prompt_logprobs is not None:
+            self.num_prompt_logprobs[req_id] = sampling_params.prompt_logprobs
+        if sampling_params.logit_bias is not None:
+            self.logit_bias[req_index] = sampling_params.logit_bias
+
+        if sampling_params.allowed_token_ids:
+            self.has_allowed_token_ids.add(req_id)
+            if self.allowed_token_ids_mask_cpu is None:
+                self.allowed_token_ids_mask_cpu = jnp.zeros(
+                    (self.max_num_reqs, self.vocab_size), dtype=jnp.bool_)
+                self.allowed_token_ids_mask = jax.device_put(
+                    jnp.zeros((self.max_num_reqs, self.vocab_size),
+                              dtype=jnp.bool_), self.device)
+
+            current_mask_row = jnp.ones(self.vocab_size, dtype=jnp.bool_)
+            allowed_indices = jnp.array(list(
+                sampling_params.allowed_token_ids),
+                                        dtype=jnp.int32)
+            current_mask_row = current_mask_row.at[allowed_indices].set(False)
+            self.allowed_token_ids_mask_cpu = self.allowed_token_ids_mask_cpu.at[
+                req_index].set(current_mask_row)
+
+        if sampling_params.bad_words_token_ids:
+            self.bad_words_token_ids[
+                req_index] = sampling_params.bad_words_token_ids
+
+        if request.lora_request:
+            lora_id = request.lora_request.lora_int_id
+            if lora_id not in self.lora_id_to_request_ids:
+                self.lora_id_to_request_ids[lora_id] = set()
+
+            self.request_lora_mapping = self.request_lora_mapping.at[
+                req_index].set(lora_id)
+            self.lora_id_to_request_ids[lora_id].add(request.req_id)
+            self.lora_id_to_lora_request[lora_id] = request.lora_request
+        else:
+            self.request_lora_mapping = self.request_lora_mapping.at[
+                req_index].set(0)
+
+    def remove_request(self, req_id: str) -> Optional[int]:
+        req_index = self.req_id_to_index.pop(req_id, None)
+        if req_index is None:
+            return None
+        self._req_ids[req_index] = None
+        self.req_output_token_ids[req_index] = None
+
+        self.greedy_reqs.discard(req_id)
+        self.random_reqs.discard(req_id)
+        self.top_p_reqs.discard(req_id)
+        self.top_k_reqs.discard(req_id)
+        self.min_p_reqs.discard(req_id)
+        self.min_tokens.pop(req_index, None)
+        self.frequency_penalties_reqs.discard(req_id)
+        self.presence_penalties_reqs.discard(req_id)
+        self.repetition_penalties_reqs.discard(req_id)
+        self.generators.pop(req_index, None)
+        self.num_logprobs.pop(req_id, None)
+        self.num_prompt_logprobs.pop(req_id, None)
+        self.in_progress_prompt_logprobs_cpu.pop(req_id, None)
+
+        lora_id = self.request_lora_mapping[req_index].item(
+        )  # .item() to get Python int
+        if lora_id != 0:
+            self.lora_id_to_request_ids[lora_id].discard(req_id)
+            if len(self.lora_id_to_request_ids[lora_id]) == 0:
+                self.lora_id_to_request_ids.pop(lora_id)
+                self.lora_id_to_lora_request.pop(lora_id)
+            self.request_lora_mapping = self.request_lora_mapping.at[
+                req_index].set(0)
+
+        self.logit_bias[req_index] = None
+        self.has_allowed_token_ids.discard(req_id)
+        if self.allowed_token_ids_mask_cpu is not None:
+            self.allowed_token_ids_mask_cpu = self.allowed_token_ids_mask_cpu.at[
+                req_index].set(False)
+        self.bad_words_token_ids.pop(req_index, None)
+        return req_index
+
+    def swap_states(self, i1: int, i2: int) -> None:
+        old_id_i1 = self._req_ids[i1]
+        old_id_i2 = self._req_ids[i2]
+        self._req_ids[i1], self._req_ids[i2] = self._req_ids[
+            i2], self._req_ids[i1]  # noqa
+        self.req_output_token_ids[i1], self.req_output_token_ids[
+            i2] = self.req_output_token_ids[i2], self.req_output_token_ids[i1]
+        assert old_id_i1 is not None and old_id_i2 is not None
+        self.req_id_to_index[old_id_i1], self.req_id_to_index[
+            old_id_i2] = self.req_id_to_index[old_id_i2], self.req_id_to_index[
+                old_id_i1]
+
+        self.num_tokens = self.num_tokens.at[i1].set(
+            self.num_tokens[i2]).at[i2].set(self.num_tokens[i1])
+        self.num_tokens_no_spec = self.num_tokens_no_spec.at[i1].set(
+            self.num_tokens_no_spec[i2]).at[i2].set(
+                self.num_tokens_no_spec[i1])
+        self.num_prompt_tokens = self.num_prompt_tokens.at[i1].set(
+            self.num_prompt_tokens[i2]).at[i2].set(self.num_prompt_tokens[i1])
+        self.num_computed_tokens_cpu = self.num_computed_tokens_cpu.at[i1].set(
+            self.num_computed_tokens_cpu[i2]).at[i2].set(
+                self.num_computed_tokens_cpu[i1])
+        self.temperature_cpu = self.temperature_cpu.at[i1].set(
+            self.temperature_cpu[i2]).at[i2].set(self.temperature_cpu[i1])
+        self.top_p_cpu = self.top_p_cpu.at[i1].set(
+            self.top_p_cpu[i2]).at[i2].set(self.top_p_cpu[i1])
+        self.top_k_cpu = self.top_k_cpu.at[i1].set(
+            self.top_k_cpu[i2]).at[i2].set(self.top_k_cpu[i1])
+        self.frequency_penalties_cpu = self.frequency_penalties_cpu.at[i1].set(
+            self.frequency_penalties_cpu[i2]).at[i2].set(
+                self.frequency_penalties_cpu[i1])
+        self.presence_penalties_cpu = self.presence_penalties_cpu.at[i1].set(
+            self.presence_penalties_cpu[i2]).at[i2].set(
+                self.presence_penalties_cpu[i1])
+        self.repetition_penalties_cpu = self.repetition_penalties_cpu.at[
+            i1].set(self.repetition_penalties_cpu[i2]).at[i2].set(
+                self.repetition_penalties_cpu[i1])
+        self.min_p_cpu = self.min_p_cpu.at[i1].set(
+            self.min_p_cpu[i2]).at[i2].set(self.min_p_cpu[i1])
+
+        tmp_row = jnp.copy(self.token_ids_cpu[i1, :])
+        self.token_ids_cpu = self.token_ids_cpu.at[i1, :].set(
+            self.token_ids_cpu[i2, :])
+        self.token_ids_cpu = self.token_ids_cpu.at[i2, :].set(tmp_row)
+
+        swap_dict_values(self.generators, i1, i2)
+        swap_dict_values(self.min_tokens, i1, i2)
+        swap_dict_values(self.bad_words_token_ids, i1, i2)
+
+        self.request_lora_mapping = self.request_lora_mapping.at[i1].set(
+            self.request_lora_mapping[i2]).at[i2].set(
+                self.request_lora_mapping[i1])
+        self.logit_bias[i1], self.logit_bias[i2] = self.logit_bias[
+            i2], self.logit_bias[i1]
+
+        if self.allowed_token_ids_mask_cpu is not None:
+            tmp_mask_row = jnp.copy(self.allowed_token_ids_mask_cpu[i1])
+            self.allowed_token_ids_mask_cpu = self.allowed_token_ids_mask_cpu.at[
+                i1].set(self.allowed_token_ids_mask_cpu[i2])
+            self.allowed_token_ids_mask_cpu = self.allowed_token_ids_mask_cpu.at[
+                i2].set(tmp_mask_row)
+        self.block_table.swap_row(i1, i2)
+
+    def condense(self, empty_req_indices: list[int]) -> None:
+        num_reqs = self.num_reqs
+        if num_reqs == 0:
+            self._req_ids.clear()
+            self.req_output_token_ids.clear()
+            return
+
+        last_req_index = num_reqs + len(empty_req_indices) - 1
+
+        # Convert lists to JAX arrays for batch updates if possible, or iterate carefully
+        # For now, direct porting of logic with JAX array updates
+
+        current_token_ids_cpu = self.token_ids_cpu
+        current_num_tokens = self.num_tokens
+        current_num_tokens_no_spec = self.num_tokens_no_spec
+        current_num_prompt_tokens = self.num_prompt_tokens
+        current_num_computed_tokens_cpu = self.num_computed_tokens_cpu
+        current_temperature_cpu = self.temperature_cpu
+        current_top_p_cpu = self.top_p_cpu
+        current_top_k_cpu = self.top_k_cpu
+        current_frequency_penalties_cpu = self.frequency_penalties_cpu
+        current_presence_penalties_cpu = self.presence_penalties_cpu
+        current_repetition_penalties_cpu = self.repetition_penalties_cpu
+        current_min_p_cpu = self.min_p_cpu
+        current_request_lora_mapping = self.request_lora_mapping
+        current_allowed_token_ids_mask_cpu = self.allowed_token_ids_mask_cpu
+
+        while empty_req_indices:
+            while last_req_index in empty_req_indices:
+                last_req_index -= 1
+
+            empty_index = empty_req_indices.pop()
+            if empty_index >= last_req_index:
+                break
+
+            req_id = self._req_ids[last_req_index]
+            output_token_ids = self.req_output_token_ids[last_req_index]
+            assert req_id is not None
+            self._req_ids[empty_index] = req_id
+            self._req_ids[last_req_index] = None
+            self.req_output_token_ids[empty_index] = output_token_ids
+            self.req_output_token_ids[last_req_index] = None
+            self.req_id_to_index[req_id] = empty_index
+
+            num_tokens_val = current_num_tokens[last_req_index].item()
+            current_token_ids_cpu = current_token_ids_cpu.at[
+                empty_index, :num_tokens_val].set(
+                    current_token_ids_cpu[last_req_index, :num_tokens_val])
+            current_num_tokens = current_num_tokens.at[empty_index].set(
+                num_tokens_val)
+            current_num_tokens_no_spec = current_num_tokens_no_spec.at[
+                empty_index].set(current_num_tokens_no_spec[last_req_index])
+            current_num_prompt_tokens = current_num_prompt_tokens.at[
+                empty_index].set(current_num_prompt_tokens[last_req_index])
+            current_num_computed_tokens_cpu = current_num_computed_tokens_cpu.at[
+                empty_index].set(
+                    current_num_computed_tokens_cpu[last_req_index])
+
+            self.block_table.move_row(last_req_index, empty_index)
+
+            current_temperature_cpu = current_temperature_cpu.at[
+                empty_index].set(current_temperature_cpu[last_req_index])
+            current_top_p_cpu = current_top_p_cpu.at[empty_index].set(
+                current_top_p_cpu[last_req_index])
+            current_top_k_cpu = current_top_k_cpu.at[empty_index].set(
+                current_top_k_cpu[last_req_index])
+            current_frequency_penalties_cpu = current_frequency_penalties_cpu.at[
+                empty_index].set(
+                    current_frequency_penalties_cpu[last_req_index])
+            current_presence_penalties_cpu = current_presence_penalties_cpu.at[
+                empty_index].set(
+                    current_presence_penalties_cpu[last_req_index])
+            current_repetition_penalties_cpu = current_repetition_penalties_cpu.at[
+                empty_index].set(
+                    current_repetition_penalties_cpu[last_req_index])
+            current_min_p_cpu = current_min_p_cpu.at[empty_index].set(
+                current_min_p_cpu[last_req_index])
+
+            generator = self.generators.pop(last_req_index, None)
+            if generator is not None:
+                self.generators[empty_index] = generator
+
+            min_token = self.min_tokens.pop(last_req_index, None)
+            if min_token is not None:
+                self.min_tokens[empty_index] = min_token
+
+            current_request_lora_mapping = current_request_lora_mapping.at[
+                empty_index].set(current_request_lora_mapping[last_req_index])
+            self.logit_bias[empty_index] = self.logit_bias[last_req_index]
+
+            if current_allowed_token_ids_mask_cpu is not None:
+                current_allowed_token_ids_mask_cpu = current_allowed_token_ids_mask_cpu.at[
+                    empty_index].set(
+                        current_allowed_token_ids_mask_cpu[last_req_index])
+
+            bad_words_token_ids = self.bad_words_token_ids.pop(
+                last_req_index, None)
+            if bad_words_token_ids is not None:
+                self.bad_words_token_ids[empty_index] = bad_words_token_ids
+            last_req_index -= 1
+
+        self.token_ids_cpu = current_token_ids_cpu
+        self.num_tokens = current_num_tokens
+        self.num_tokens_no_spec = current_num_tokens_no_spec
+        self.num_prompt_tokens = current_num_prompt_tokens
+        self.num_computed_tokens_cpu = current_num_computed_tokens_cpu
+        self.temperature_cpu = current_temperature_cpu
+        self.top_p_cpu = current_top_p_cpu
+        self.top_k_cpu = current_top_k_cpu
+        self.frequency_penalties_cpu = current_frequency_penalties_cpu
+        self.presence_penalties_cpu = current_presence_penalties_cpu
+        self.repetition_penalties_cpu = current_repetition_penalties_cpu
+        self.min_p_cpu = current_min_p_cpu
+        self.request_lora_mapping = current_request_lora_mapping
+        self.allowed_token_ids_mask_cpu = current_allowed_token_ids_mask_cpu
+
+        del self._req_ids[self.num_reqs:]
+        del self.req_output_token_ids[self.num_reqs:]
+
+    def refresh_sampling_metadata(self):
+        self.sampling_metadata = self._make_sampling_metadata()
+
+    def _make_sampling_metadata(self) -> SamplingMetadata:
+        num_reqs = self.num_reqs
+        temperature_for_metadata: Optional[jax.Array] = None
+        top_p_for_metadata: Optional[jax.Array] = None
+        top_k_for_metadata: Optional[jax.Array] = None
+        min_p_for_metadata: Optional[jax.Array] = None
+        prompt_token_ids: Optional[jax.Array] = None
+        allowed_token_ids_mask_for_metadata: Optional[jax.Array] = None
+
+        if not self.all_greedy:
+            self.temperature = self.temperature.at[:num_reqs].set(
+                self.temperature_cpu[:num_reqs])
+            temperature_for_metadata = self.temperature[:num_reqs]
+
+        if not self.no_top_p:
+            self.top_p = self.top_p.at[:num_reqs].set(
+                self.top_p_cpu[:num_reqs])
+            top_p_for_metadata = self.top_p[:num_reqs]
+        if not self.no_top_k:
+            self.top_k = self.top_k.at[:num_reqs].set(
+                self.top_k_cpu[:num_reqs])
+            top_k_for_metadata = self.top_k[:num_reqs]
+        if not self.no_min_p:
+            self.min_p = self.min_p.at[:num_reqs].set(
+                self.min_p_cpu[:num_reqs])
+            min_p_for_metadata = self.min_p[:num_reqs]
+
+        if not self.no_penalties:
+            self.frequency_penalties = self.frequency_penalties.at[:num_reqs].set(
+                self.frequency_penalties_cpu[:num_reqs])
+            self.presence_penalties = self.presence_penalties.at[:num_reqs].set(
+                self.presence_penalties_cpu[:num_reqs])
+            self.repetition_penalties = self.repetition_penalties.at[:num_reqs].set(
+                self.repetition_penalties_cpu[:num_reqs])
+            prompt_token_ids = self._make_prompt_token_ids_tensor()
+
+        if not self.no_allowed_token_ids:
+            assert self.allowed_token_ids_mask is not None and self.allowed_token_ids_mask_cpu is not None
+            self.allowed_token_ids_mask = self.allowed_token_ids_mask.at[:num_reqs].set(
+                self.allowed_token_ids_mask_cpu[:num_reqs])
+            allowed_token_ids_mask_for_metadata = self.allowed_token_ids_mask[:
+                                                                              num_reqs]
+
+        return SamplingMetadata(
+            temperature=temperature_for_metadata,
+            all_greedy=self.all_greedy,
+            all_random=self.all_random,
+            top_p=top_p_for_metadata,
+            top_k=top_k_for_metadata,
+            min_p=min_p_for_metadata,
+            generators=self.generators,
+            max_num_logprobs=self.max_num_logprobs,
+            prompt_token_ids=prompt_token_ids,
+            frequency_penalties=self.frequency_penalties[:num_reqs]
+            if not self.no_penalties else None,
+            presence_penalties=self.presence_penalties[:num_reqs]
+            if not self.no_penalties else None,
+            repetition_penalties=self.repetition_penalties[:num_reqs]
+            if not self.no_penalties else None,
+            output_token_ids=cast(list[list[int]], self.req_output_token_ids),
+            min_tokens=self.min_tokens,
+            no_penalties=self.no_penalties,
+            logit_bias=self.logit_bias[:num_reqs],
+            allowed_token_ids_mask=allowed_token_ids_mask_for_metadata,
+            bad_words_token_ids=self.bad_words_token_ids,
+        )
+
+    def _make_prompt_token_ids_tensor(self) -> jax.Array:
+        if self.num_reqs == 0:
+            return jax.device_put(jnp.empty((0, 0), dtype=jnp.int64),
+                                  self.device)
+
+        max_prompt_len = self.num_prompt_tokens[:self.num_reqs].max().item()
+        if max_prompt_len == 0:  # Handle case where all prompts are empty
+            return jax.device_put(
+                jnp.empty((self.num_reqs, 0), dtype=jnp.int64), self.device)
+
+        prompt_token_ids_host = jnp.empty(
+            (self.num_reqs, max_prompt_len),
+            dtype=jnp.int64,
+        )
+
+        prompt_token_ids_host = prompt_token_ids_host.at[:, :].set(
+            self.token_ids_cpu[:self.num_reqs, :max_prompt_len].astype(
+                jnp.int64))
+
+        for i in range(self.num_reqs):
+            num_prompt_tokens_i = self.num_prompt_tokens[i].item()
+            if num_prompt_tokens_i < max_prompt_len:
+                prompt_token_ids_host = prompt_token_ids_host.at[
+                    i, num_prompt_tokens_i:].set(self.vocab_size)
+
+        return jax.device_put(prompt_token_ids_host, self.device)
+
+    def make_lora_inputs(
+        self,
+        num_scheduled_tokens: jax.Array  # Changed from np.ndarray
+    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest]]:
+        req_lora_mapping_slice = self.request_lora_mapping[:self.num_reqs]
+        prompt_lora_mapping = tuple(
+            map(int, req_lora_mapping_slice
+                ))  # Convert JAX array elements to Python int for tuple
+
+        # jnp.repeat requires repeats to be an int or sequence of ints.
+        # num_scheduled_tokens is a JAX array of token counts per request.
+        # Ensure num_scheduled_tokens are Python integers for repeat if it's small or convert to list
+        if num_scheduled_tokens.size > 0:  # Check if there are any tokens scheduled
+            # Convert JAX array elements to Python int for jnp.repeat if needed, or ensure dtype is int.
+            repeats_for_tokens = num_scheduled_tokens.astype(
+                jnp.int32)  # Ensure integer type
+            token_lora_mapping_array = jnp.repeat(
+                req_lora_mapping_slice,
+                repeats_for_tokens,
+                total_repeat_length=jnp.sum(repeats_for_tokens).item())
+            token_lora_mapping = tuple(map(int, token_lora_mapping_array))
+        else:
+            token_lora_mapping = tuple()
+
+        active_lora_requests: set[LoRARequest] = set(
+            self.lora_id_to_lora_request.values())
+
+        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
+
+    @property
+    def num_reqs(self) -> int:
+        return len(self.req_id_to_index)
+
+    @property
+    def all_greedy(self) -> bool:
+        return len(self.random_reqs) == 0
+
+    @property
+    def all_random(self) -> bool:
+        return len(self.greedy_reqs) == 0
+
+    @property
+    def no_top_p(self) -> bool:
+        return len(self.top_p_reqs) == 0
+
+    @property
+    def no_top_k(self) -> bool:
+        return len(self.top_k_reqs) == 0
+
+    @property
+    def no_min_p(self) -> bool:
+        return len(self.min_p_reqs) == 0
+
+    @property
+    def no_penalties(self) -> bool:
+        return (len(self.presence_penalties_reqs) == 0
+                and len(self.frequency_penalties_reqs) == 0
+                and len(self.repetition_penalties_reqs) == 0)
+
+    @property
+    def max_num_logprobs(self) -> Optional[int]:
+        return max(self.num_logprobs.values()) if self.num_logprobs else None
+
+    @property
+    def no_prompt_logprob(self) -> bool:
+        return not self.num_prompt_logprobs
+
+    @property
+    def no_allowed_token_ids(self) -> bool:
+        return len(self.has_allowed_token_ids) == 0

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -98,6 +98,7 @@ class TPUModelRunner(LoRAModelRunnerMixin):
         vllm_config: VllmConfig,
         device: torch.device,
     ):
+        assert False
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
         self.cache_config = vllm_config.cache_config

--- a/vllm/v1/worker/tpu_model_runner_jax.py
+++ b/vllm/v1/worker/tpu_model_runner_jax.py
@@ -1,0 +1,414 @@
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+from vllm.v1.worker.input_batch_jax import InputBatch as InputBatchJax
+from vllm.v1.worker.tpu_model_runner import *
+from vllm.v1.worker.tpu_model_runner import (_get_req_paddings,
+                                             _get_token_paddings)
+
+logger = init_logger(__name__)
+
+
+class TPUModelRunnerJax:
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: Any,
+    ):
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.lora_config = vllm_config.lora_config
+        self.load_config = vllm_config.load_config
+        self.parallel_config = vllm_config.parallel_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.speculative_config = vllm_config.speculative_config
+        self.prompt_adapter_config = vllm_config.prompt_adapter_config
+        self.observability_config = vllm_config.observability_config
+        self.device_config = vllm_config.device_config
+
+        model_config = self.model_config
+        cache_config = self.cache_config
+        scheduler_config = self.scheduler_config
+        parallel_config = self.parallel_config
+        self.device = device
+        self.check_recompilation = envs.VLLM_XLA_CHECK_RECOMPILATION
+
+        self.enforce_eager = model_config.enforce_eager
+
+        self.num_xla_graphs = 0
+        self.kv_caches: list[jax.Array] = []
+
+        self.pin_memory = is_pin_memory_available()
+        self.dtype = self.model_config.dtype
+        self._hidden_states_dtype = self.dtype
+
+        self.is_multimodal_model = model_config.is_multimodal_model
+        self.sliding_window = model_config.get_sliding_window()
+        self.block_size = cache_config.block_size
+        self.max_model_len = model_config.max_model_len
+        self.max_num_blocks_per_req = cdiv(self.max_model_len, self.block_size)
+        # InputBatch needs to work with sampling tensors greater than padding
+        # to avoid dynamic shapes. Also, avoid suboptimal alignment.
+        self.max_num_reqs = max(scheduler_config.max_num_seqs, MIN_NUM_SEQS)
+        self.num_tokens_paddings = _get_token_paddings(
+            min_token_size=16,
+            max_token_size=scheduler_config.max_num_batched_tokens,
+            padding_gap=envs.VLLM_TPU_BUCKET_PADDING_GAP)
+        # In case `max_num_tokens < max(num_tokens_paddings)` use the actual
+        # padded max value to pre-allocate data structures and pre-compile.
+        self.max_num_tokens = self.num_tokens_paddings[-1]
+
+        # Model-related.
+        self.num_attn_layers = model_config.get_num_layers_by_block_type(
+            parallel_config, LayerBlockType.attention)
+        self.num_query_heads = model_config.get_num_attention_heads(
+            parallel_config)
+        self.num_kv_heads = model_config.get_num_kv_heads(parallel_config)
+        self.head_size = model_config.get_head_size()
+        self.hidden_size = model_config.get_hidden_size()
+        self.vocab_size = model_config.get_vocab_size()
+
+        # Multi-modal data support
+        self.mm_registry = MULTIMODAL_REGISTRY
+        self.uses_mrope = model_config.uses_mrope
+        # TODO: Support M-RoPE (e.g, Qwen2-VL)
+        assert not self.uses_mrope, "TPU does not support M-RoPE yet."
+
+        encoder_compute_budget, encoder_cache_size = compute_encoder_budget(
+            model_config=model_config,
+            scheduler_config=scheduler_config,
+            mm_registry=self.mm_registry,
+        )
+        self.max_num_encoder_input_tokens = encoder_compute_budget
+        self.encoder_cache_size = encoder_cache_size
+
+        # Lazy initialization
+        # self.model: nn.Module  # Set after load_model
+
+        # req_id -> (input_id -> encoder_output)
+        self.encoder_cache: dict[str, dict[int, jax.Array]] = {}
+
+        # Request states.
+        self.requests: dict[str, CachedRequestState] = {}
+        # Persistent batch.
+        self.input_batch = InputBatchJax(
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=self.max_model_len,
+            max_num_blocks_per_req=self.max_num_blocks_per_req,
+            max_num_batched_tokens=self.max_num_tokens,
+            device=self.device,
+            pin_memory=self.pin_memory,
+            vocab_size=self.vocab_size,
+        )
+
+        self.input_ids = jnp.zeros((self.max_num_tokens, ), dtype=jnp.int32)
+
+        self.positions = jnp.zeros((self.max_num_tokens, ), dtype=jnp.int32)
+
+        # Assuming self.input_batch.block_table is already a JAX array
+        # Access its dtype directly
+        block_table_dtype = self.input_batch.block_table.dtype
+        self.block_table = jnp.zeros(
+            (self.max_num_reqs, self.max_num_blocks_per_req),
+            dtype=block_table_dtype)
+
+        self.query_start_loc = jnp.zeros((self.max_num_tokens + 1, ),
+                                         dtype=jnp.int32)
+
+        self.seq_lens = jnp.zeros((self.max_num_tokens, ), dtype=jnp.int32)
+
+        # Range tensor with values [0 .. self.max_num_tokens - 1].
+        # Used to initialize positions / context_lens / seq_lens
+        # Keep in int64 to avoid overflow with long context
+        self.arange_np = np.arange(self.max_num_tokens, dtype=np.int64)
+        self.num_reqs_paddings = _get_req_paddings(
+            min_req_size=MIN_NUM_SEQS, max_req_size=self.max_num_reqs)
+
+    def _update_num_xla_graphs(self, case_str):
+        return
+
+    def _verify_num_xla_graphs(self, case_str):
+        return
+
+    def _update_states(self, scheduler_output: "SchedulerOutput") -> bool:
+        """Update the cached states and the persistent batch with the scheduler
+        output.
+
+        The updated states are used by the `_prepare_inputs` function to create
+        the input GPU tensors for the model.
+
+        Returns:
+            True if there is a new/resumed/paused/finished request.
+            If False, we can skip copying SamplingMetadata to the GPU.
+        """
+        # Remove finished requests from the cached states.
+        for req_id in scheduler_output.finished_req_ids:
+            self.requests.pop(req_id, None)
+            self.encoder_cache.pop(req_id, None)
+
+        # Remove the finished requests from the persistent batch.
+        # NOTE(woosuk): There could be an edge case where finished_req_ids and
+        # scheduled_req_ids overlap. This happens when a request is aborted and
+        # then resubmitted with the same ID. In this case, we treat them as two
+        # distinct requests - clearing the cached states for the first request
+        # and handling the second as a new request.
+        removed_req_indices: list[int] = []
+        for req_id in scheduler_output.finished_req_ids:
+            req_index = self.input_batch.remove_request(req_id)
+            if req_index is not None:
+                removed_req_indices.append(req_index)
+
+        # Free the cached encoder outputs.
+        for req_id, input_id in scheduler_output.free_encoder_input_ids:
+            encoder_outputs = self.encoder_cache.get(req_id)
+            if encoder_outputs is not None:
+                encoder_outputs.pop(input_id, None)
+                if not encoder_outputs:
+                    self.encoder_cache.pop(req_id, None)
+
+        # Remove the unscheduled requests from the persistent batch.
+        # NOTE(woosuk): The unscheduled requests are either preempted requests
+        # or running requests that are not scheduled in this step. We remove
+        # them from the persistent batch but keep their cached states since
+        # they will be scheduled again sometime in the future.
+        scheduled_req_ids = scheduler_output.num_scheduled_tokens.keys()
+        cached_req_ids = self.input_batch.req_id_to_index.keys()
+        unscheduled_req_ids = cached_req_ids - scheduled_req_ids
+        # NOTE(woosuk): The persistent batch optimization assumes that
+        # consecutive batches contain mostly the same requests. If batches
+        # have low request overlap (e.g., alternating between two distinct
+        # sets of requests), this optimization becomes very inefficient.
+        for req_id in unscheduled_req_ids:
+            req_index = self.input_batch.remove_request(req_id)
+            assert req_index is not None
+            removed_req_indices.append(req_index)
+
+        req_ids_to_add: list[str] = []
+        # Add new requests to the cached states.
+        for new_req_data in scheduler_output.scheduled_new_reqs:
+            req_id = new_req_data.req_id
+            sampling_params = new_req_data.sampling_params
+
+            self.requests[req_id] = CachedRequestState(
+                req_id=req_id,
+                prompt_token_ids=new_req_data.prompt_token_ids,
+                mm_inputs=new_req_data.mm_inputs,
+                mm_positions=new_req_data.mm_positions,
+                sampling_params=sampling_params,
+                generator=None,
+                block_ids=new_req_data.block_ids,
+                num_computed_tokens=new_req_data.num_computed_tokens,
+                output_token_ids=[],
+                lora_request=new_req_data.lora_request,
+            )
+
+            req_ids_to_add.append(req_id)
+
+        # Update the states of the running/resumed requests.
+        for req_data in scheduler_output.scheduled_cached_reqs:
+            req_id = req_data.req_id
+            req_state = self.requests[req_id]
+
+            # Update the cached states.
+            req_state.num_computed_tokens = req_data.num_computed_tokens
+            if not req_data.resumed_from_preemption:
+                # Append the new blocks to the existing block IDs.
+                req_state.block_ids.extend(req_data.new_block_ids)
+            else:
+                # The request is resumed from preemption.
+                # Replace the existing block IDs with the new ones.
+                req_state.block_ids = req_data.new_block_ids
+
+            req_index = self.input_batch.req_id_to_index.get(req_id)
+            if req_index is None:
+                # The request is not in the persistent batch.
+                # The request was either preempted and resumed later, or was not
+                # scheduled in the previous step and needs to be added again.
+                req_ids_to_add.append(req_id)
+                continue
+
+            # Update the persistent batch.
+            self.input_batch.num_computed_tokens_cpu[req_index] = (
+                req_data.num_computed_tokens)
+            self.input_batch.block_table.append_row(req_data.new_block_ids,
+                                                    req_index)
+
+        # Add the new or resumed requests to the persistent batch.
+        # The smaller empty indices are filled first.
+        removed_req_indices = sorted(removed_req_indices, reverse=True)
+        for req_id in req_ids_to_add:
+            req_state = self.requests[req_id]
+            if removed_req_indices:
+                # Fill the empty index.
+                req_index = removed_req_indices.pop()
+            else:
+                # Append to the end.
+                req_index = None
+            self.input_batch.add_request(req_state, req_index)
+
+        # Condense the batched states if there are empty indices.
+        if removed_req_indices:
+            self.input_batch.condense(removed_req_indices)
+
+        return len(unscheduled_req_ids) > 0 or len(req_ids_to_add) > 0
+
+    def get_model(self):
+        assert self.model is not None
+        return self.model
+
+    def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
+        """
+        Generates the KVCacheSpec by parsing the kv cache format from each
+        Attention module in the static forward context.
+        Returns:
+            KVCacheSpec: A dictionary mapping layer names to their KV cache
+            format. Layers that do not need KV cache are not included.
+        """
+        block_size = self.vllm_config.cache_config.block_size
+        kv_cache_spec: dict[str, KVCacheSpec] = {}
+        model_config = self.vllm_config.model_config
+        parallel_config = self.vllm_config.parallel_config
+        for i in range(model_config.get_num_layers(parallel_config)):
+            kv_cache_spec[f"layers.{i}"] = FullAttentionSpec(
+                block_size=block_size,
+                num_kv_heads=model_config.get_num_attention_heads(
+                    parallel_config),
+                head_size=model_config.get_head_size(),
+                dtype=jnp.bfloat16,
+                use_mla=False,
+            )
+
+        return kv_cache_spec
+
+    def _get_model_inputs(self, input_ids: torch.Tensor,
+                          mm_embeds: list[torch.Tensor]):
+        return input_ids, None
+
+    def load_model(self) -> None:
+        self.device = self.device_config.device
+        model = get_model(vllm_config=self.vllm_config)
+        self.model = model
+
+    def _dummy_run(self, num_tokens: int) -> None:
+        if self.model is None:
+            self.load_model()
+
+        input_ids = jnp.zeros((num_tokens, ), dtype=jnp.int32)
+        # device=device) # Explicit placement if needed
+
+        inputs_embeds = None  # Remains None
+
+        actual_num_reqs = min(num_tokens, self.max_num_reqs)
+
+        position_ids = jnp.zeros((num_tokens, ), dtype=jnp.int32)
+        # device=device) # Explicit placement if needed
+
+        slot_mapping = jnp.zeros(
+            (num_tokens, ), dtype=jnp.int64)  # Note: JAX default int is int32
+        # device=device) # Explicit placement if needed
+
+        block_tables = jnp.zeros(
+            (self.max_num_reqs,
+             self.block_table.shape[1]),  # Use shape directly
+            dtype=jnp.int32)
+        # device=device) # Explicit placement if needed
+
+        query_lens = [1] * self.max_num_reqs  # Standard Python list
+
+        # JAX equivalent for cumsum and tensor creation
+        # Create the initial array, potentially on the device
+        initial_query_loc = jnp.array([0] + query_lens, dtype=jnp.int32)
+        # device=device) # Explicit placement if needed
+
+        # Perform cumsum. The result typically stays on the same device.
+        query_start_loc = jnp.cumsum(initial_query_loc,
+                                     axis=0,
+                                     dtype=jnp.int32)
+
+        context_lens = jnp.ones((self.max_num_reqs, ), dtype=jnp.int32)
+        # device=device) # Explicit placement if needed
+
+        num_seqs = jnp.array([actual_num_reqs], dtype=jnp.int32)
+        # device=device) # Explicit placement if needed
+        attn_metadata = PallasMetadata(
+            slot_mapping=slot_mapping,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            query_start_loc=query_start_loc,
+            num_seqs=num_seqs,
+        )
+
+        layer_names = get_layers_from_vllm_config(self.vllm_config,
+                                                  Attention).keys()
+        per_layer_attn_metadata = {
+            layer_name: attn_metadata
+            for layer_name in layer_names
+        }
+
+        out = self.model(input_ids=input_ids,
+                         positions=position_ids,
+                         inputs_embeds=inputs_embeds)
+
+        return out
+
+    def profile_run(self, num_tokens: int):
+        self._dummy_run(num_tokens)
+
+    def _precompile_backbone(self) -> None:
+        logger.info("Compiling the model with different input shapes.")
+        start = time.perf_counter()
+        for num_tokens in self.num_tokens_paddings:
+            logger.info("  -- num_tokens: %d", num_tokens)
+            self._dummy_run(num_tokens)
+        end = time.perf_counter()
+        logger.info("Compilation finished in %.2f [secs].", end - start)
+
+    def capture_model(self) -> None:
+        """
+        Precompile all the subgraphs with possible input shapes.
+        """
+        self._precompile_backbone()
+        print(">>>>> Ready to be submitted <<<<<")
+        assert False
+
+    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        """
+        Initialize KV cache based on `kv_cache_config`.
+        Args:
+            kv_cache_config: Configuration for the KV cache, including the KV
+            cache size of each layer
+        """
+        if len(kv_cache_config.kv_cache_groups) > 1:
+            raise NotImplementedError(
+                "Hybrid models with more than one KV cache type are not "
+                "supported yet.")
+
+        kv_caches: dict[str, torch.Tensor] = {}
+
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            kv_cache_spec = kv_cache_group.kv_cache_spec
+            for layer_name in kv_cache_group.layer_names:
+                tensor_config = kv_cache_config.tensors[layer_name]
+                assert tensor_config.size % kv_cache_spec.page_size_bytes == 0
+                num_blocks = tensor_config.size // kv_cache_spec.page_size_bytes
+                if isinstance(kv_cache_spec, AttentionSpec):
+                    kv_cache_shape = PallasAttentionBackend.get_kv_cache_shape(
+                        num_blocks, kv_cache_spec.block_size,
+                        kv_cache_spec.num_kv_heads, kv_cache_spec.head_size)
+                    dtype = kv_cache_spec.dtype
+
+                    tpu_kv_cache = jnp.zeros(kv_cache_shape, dtype=dtype)
+
+                    kv_caches[layer_name] = tpu_kv_cache
+                else:
+                    raise NotImplementedError
+
+        bind_kv_cache(
+            kv_caches,
+            self.vllm_config.compilation_config.static_forward_context,
+            self.kv_caches)

--- a/vllm/v1/worker/tpu_worker_jax.py
+++ b/vllm/v1/worker/tpu_worker_jax.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+import jax
+import jax.numpy as jnp
+
+from vllm.v1.worker.tpu_model_runner_jax import TPUModelRunnerJax
+from vllm.v1.worker.tpu_worker import *
+
+
+class JAXTPUWorker(TPUWorker):
+
+    def init_device(self):
+        self.device = jax.devices()[0]
+        self.model_runner = TPUModelRunnerJax(self.vllm_config, self.device)
+
+    def determine_available_memory(self) -> int:
+        kv_caches: dict[str, torch.Tensor] = {}
+        kv_cache_spec = self.model_runner.get_kv_cache_spec()
+        for layer_name, layer_spec in kv_cache_spec.items():
+            if isinstance(layer_spec, AttentionSpec):
+                dtype = layer_spec.dtype
+
+                # Use an empty tensor instead of `None`` to force Dynamo to pass
+                # it by reference, rather by specializing on the value ``None``.
+                tpu_kv_cache = jnp.array([], dtype=dtype)
+
+                kv_caches[layer_name] = tpu_kv_cache
+            else:
+                raise NotImplementedError(
+                    f"Unsupported KV cache spec '{type(layer_spec)}'")
+
+        runner_kv_caches: list[torch.Tensor] = []
+        bind_kv_cache(
+            kv_caches,
+            self.vllm_config.compilation_config.static_forward_context,
+            runner_kv_caches)
+
+        # `max_num_tokens >= max_num_batched_tokens` due to padding.
+        self.model_runner.profile_run(self.model_runner.max_num_tokens)
+        return 1e10


### PR DESCRIPTION
Hack vllm to support JAX model runner:

```
VLLM_USE_JAX=1 python examples/offline_inference/basic/generate.py --task=generate --max_model_len=1024
```
